### PR TITLE
[Fix]: Add early return to prevent crashes caused by player being null

### DIFF
--- a/Fabric/gradle.properties
+++ b/Fabric/gradle.properties
@@ -9,7 +9,7 @@ loader_version = 0.14.21
 fabric_version = 0.87.0+1.20.1
 
 # Mod Properties
-mod_version=1.4.1
+mod_version=1.4.2
 maven_group=com.tom5454.createoreexcavation
 archives_base_name=createoreexcavation-fabric-1.20
 

--- a/Fabric/src/main/java/com/tom/createores/client/CreateOreExcavationClient.java
+++ b/Fabric/src/main/java/com/tom/createores/client/CreateOreExcavationClient.java
@@ -42,6 +42,7 @@ public class CreateOreExcavationClient implements ClientModInitializer {
 	}
 
 	public static void appendVariableStress(List<Component> tooltip) {
+		if (Minecraft.getInstance().player == null) return;
 		boolean hasGoggles = GogglesItem.isWearingGoggles(Minecraft.getInstance().player);
 		boolean hasStressImpact = StressImpact.isEnabled();
 		LangBuilder rpmUnit = Lang.translate("generic.unit.rpm");


### PR DESCRIPTION
I have noticed that polymer may cause the tooltip event to trigger before the player is loaded, causing a crash, this PR adds a line to return early on the method to avoid a NullPointerException crash caused by null player.